### PR TITLE
feat(VNodeProps): class reducer

### DIFF
--- a/src/hyperscript/h.test.ts
+++ b/src/hyperscript/h.test.ts
@@ -46,6 +46,19 @@ describe('h', () => {
     });
   });
 
+  describe('given a class in props, selector is rendered properly', () => {
+    it('returns a vNode with id and className of correct value', () => {
+      const id = 'dynamic-class';
+      const className = 'base.class';
+      const classNames = { foo: true, bar: true, not: false, this: false };
+      const expectedClass = 'base class foo bar';
+      const vNode = h('div#' + id + '.' + className,  { class: classNames });
+
+      assert.strictEqual(vNode.id, id);
+      assert.strictEqual(vNode.className, expectedClass);
+    });
+  });
+
   describe('given a props object as second parameter', () => {
     it('correctly sets vNode.props', () => {
       const props = {};

--- a/src/hyperscript/h.ts
+++ b/src/hyperscript/h.ts
@@ -7,6 +7,7 @@ export const h: HyperscriptFn = function h(): VNode {
   const selector: string = arguments[0]; // required
   let childrenOrText: Array<VNode | string> | string = arguments[2]; // optional
 
+  let { tagName, id, className } = parseSelector(selector);
   let props: VNodeProps = {};
   let children: Array<VNode> | void;
   let text: string | void;
@@ -30,7 +31,11 @@ export const h: HyperscriptFn = function h(): VNode {
       props = childrenOrTextOrProps;
   }
 
-  const { tagName, id, className } = parseSelector(selector);
+  if (props && props.class && typeof props.class === 'object') {
+    const ck = Object.keys(props.class);
+    const cp = props.class;
+    className = ck.reduce((cn, k) => cp[k] ? `${cn} ${k}` : cn, className);
+  }
 
   const isSvg = tagName === 'svg';
 

--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -4,6 +4,7 @@ import { emptyVNode } from './emptyVNode';
 
 const PROPERTIES_TO_SKIP: Array<string> =
   [
+    'class',
     'style',
     'attrs',
     'key',

--- a/src/types/VirtualNode.ts
+++ b/src/types/VirtualNode.ts
@@ -44,6 +44,9 @@ export interface VNodeProps extends HtmlProperties {
   // key for dom diffing
   key?: string | number;
 
+  // classes
+  class?: { [className: string]: Boolean };
+
   // attributes for setAttribute()
   attrs?: { [attributeName: string]: any };
 


### PR DESCRIPTION
Add ability to give in extra classes as a key-value dictionary where the key is the className and the value is a Boolean indicating whether it should be applied or not

AFFECTS:
VNodeProps
HyperSctipyFn

- [x] I added new tests for the issue I fixed or the feature I built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`