### PR TITLE
feat: many breaking changes

### DIFF
--- a/src/createElement.test.ts
+++ b/src/createElement.test.ts
@@ -16,22 +16,6 @@ describe('createElement', () => {
     assert.strictEqual((element as Element).tagName, 'DIV')
   })
 
-  it('creates an element with an id', () => {
-    const vNode = h('div#id')
-
-    const element = createElement(vNode, moduleCallbacks, []).element as HTMLDivElement
-
-    assert.strictEqual(element.id, 'id')
-  })
-
-  it('creates an element with a className', () => {
-    const vNode = h('div.className')
-
-    const element = createElement(vNode, moduleCallbacks, []).element as HTMLDivElement
-
-    assert.strictEqual(element.className, 'className')
-  })
-
   it('creates an element with children', () => {
     const vNode = h('div', {}, [
       h('h1', 'Hello'),

--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -20,12 +20,6 @@ export function createElement(
       ? document.createElementNS(vNode.namespace, vNode.tagName)
       : document.createElement(vNode.tagName)
 
-    if (vNode.id)
-      element.id = vNode.id
-
-    if (vNode.className)
-      element.className = vNode.className
-
     if (vNode.scope)
       element.setAttribute(SCOPE_ATTRIBUTE, vNode.scope)
 

--- a/src/elementToVNode.ts
+++ b/src/elementToVNode.ts
@@ -5,9 +5,10 @@ import { VOID } from './helpers'
 export function elementToVNode<T extends Element>(element: T): ElementVNode<T> {
   return new MostlyVNode<T>(
     element.tagName && element.tagName.toLowerCase(),
-    element.id,
-    element.className,
-    {},
+    {
+      id: element.id,
+      className: element.className
+    },
     Array.prototype.slice.call(element.childNodes).map(nodeToVNode) || VOID,
     element,
     VOID,

--- a/src/hyperscript/VNode.ts
+++ b/src/hyperscript/VNode.ts
@@ -11,8 +11,6 @@ export class MostlyVNode<T extends Node> implements VNode<T> {
 
   constructor(
     public tagName: string | void,
-    public id: string | void,
-    public className: string | void,
     public props: VNodeProps<Element>,
     public children: Array<VNode<Node>> | ReadonlyArray<VNode<Node>> | void,
     public element: T | void,
@@ -24,33 +22,29 @@ export class MostlyVNode<T extends Node> implements VNode<T> {
 
   public static create<N extends Node>(
     tagName: string | void,
-    id: string | void,
-    className: string | void,
     props: VNodeProps<Element>,
     children: Array<VNode<Node>> | ReadonlyArray<VNode<Node>> | void,
     text: string | void,
   )
   {
     return new MostlyVNode<N>(
-      tagName, id, className, props, children, VOID, text, props.key, props.scope, VOID)
+      tagName, props, children, VOID, text, props.key, props.scope, VOID)
   }
 
   public static createText(text: string): MostlyVNode<Text> {
     return new MostlyVNode<Text>(
-      VOID, VOID, VOID, defaultTextNodeData, VOID, VOID, text, VOID, VOID, VOID)
+      VOID, defaultTextNodeData, VOID, VOID, text, VOID, VOID, VOID)
   }
 
   public static createSvg(
     tagName: string | void,
-    id: string | void,
-    className: string | void,
     props: VNodeProps<SVGElement>,
     children: Array<VNode<Node>> | ReadonlyArray<VNode<Node>> | void,
     text: string | void,
   )
   {
     return new MostlyVNode<SVGElement>(
-      tagName, id, className, props, children, VOID, text, props.key, props.scope, SVG_NAMESPACE)
+      tagName, props, children, VOID, text, props.key, props.scope, SVG_NAMESPACE)
   }
 }
 

--- a/src/hyperscript/h.test.ts
+++ b/src/hyperscript/h.test.ts
@@ -15,51 +15,6 @@ describe('h', () => {
     })
   })
 
-  describe('given a selector representing a tagName and className', () => {
-    it('returns a vNode with className of same value', () => {
-      const className = 'hello'
-
-      const vNode = h('div.' + className)
-
-      assert.strictEqual(vNode.className, className)
-    })
-  })
-
-  describe('given a selector representing a tagName and id', () => {
-    it('returns a vNode with id of same value', () => {
-      const id = 'hello'
-
-      const vNode = h('div#' + id)
-
-      assert.strictEqual(vNode.id, id)
-    })
-  })
-
-  describe('given a selector representing a tagName id and className', () => {
-    it('returns a vNode with id and className of correct value', () => {
-      const id = 'hello'
-      const className = 'other'
-
-      const vNode = h('div#' + id + '.' + className)
-
-      assert.strictEqual(vNode.id, id)
-      assert.strictEqual(vNode.className, className)
-    })
-  })
-
-  describe('given a class in props, selector is rendered properly', () => {
-    it('returns a vNode with id and className of correct value', () => {
-      const id = 'dynamic-class'
-      const className = 'base.class'
-      const classNames = { foo: true, bar: true, not: false, this: false }
-      const expectedClass = 'base class foo bar'
-      const vNode = h('div#' + id + '.' + className, { class: classNames })
-
-      assert.strictEqual(vNode.id, id)
-      assert.strictEqual(vNode.className, expectedClass)
-    })
-  })
-
   describe('given a props object as second parameter', () => {
     it('correctly sets vNode.props', () => {
       const props = {}

--- a/src/hyperscript/h.ts
+++ b/src/hyperscript/h.ts
@@ -1,15 +1,11 @@
+import { HtmlTagNames, SvgTagNames, VNode, VNodeProps } from '../types'
 import { MostlyVNode, addSvgNamespace } from './VNode'
-import { VNode, VNodeProps } from '../types'
 import { VOID, isPrimitive, isString } from '../helpers'
 
-import { parseSelector } from './parseSelector'
-
 export const h: HyperscriptFn = function(): VNode {
-  const selector: string = arguments[0] // required
+  const tagName: string = arguments[0] // required
   const childrenOrText: Array<VNode | string> | string = arguments[2] // optional
 
-  // tslint:disable-next-line:prefer-const
-  let { tagName, id, className } = parseSelector(selector)
   let props: VNodeProps<Element> = {}
   let children: Array<VNode> | void
   let text: string | void
@@ -33,17 +29,11 @@ export const h: HyperscriptFn = function(): VNode {
       props = childrenOrTextOrProps
   }
 
-  if (props && props.class && typeof props.class === 'object') {
-    const ck = Object.keys(props.class)
-    const cp = props.class
-    className = ck.reduce((cn, k) => cp[k] ? `${cn} ${k}` : cn, className)
-  }
-
   const isSvg = tagName === 'svg'
 
   const vNode = isSvg
-    ? MostlyVNode.createSvg(tagName, id, className, props, VOID, text)
-    : MostlyVNode.create(tagName, id, className, props, VOID, text)
+    ? MostlyVNode.createSvg(tagName, props, VOID, text)
+    : MostlyVNode.create(tagName, props, VOID, text)
 
   if (Array.isArray(children))
     vNode.children = sanitizeChildren(children, vNode)
@@ -83,23 +73,25 @@ export type HyperscriptChildren =
   Array<string | VNode | null> |
   ReadonlyArray<string | VNode | null>
 
+export type ValidTagNames = HtmlTagNames | SvgTagNames
+
 export interface HyperscriptFn {
-  (sel: string): VNode
-  (sel: string, data: VNodeProps<any>): VNode
-  (sel: string, children: HyperscriptChildren): VNode
-  (sel: string, data: VNodeProps<any>, children: HyperscriptChildren): VNode
+  (tagName: ValidTagNames): VNode
+  (tagName: ValidTagNames, props: VNodeProps<any>): VNode
+  (tagName: ValidTagNames, children: HyperscriptChildren): VNode
+  (tagName: ValidTagNames, props: VNodeProps<any>, children: HyperscriptChildren): VNode
 
   <T extends Node, Props extends VNodeProps<Element> = VNodeProps<Element>>(
-    sel: string): VNode<T, Props>
+    tagName: ValidTagNames): VNode<T, Props>
   <T extends Node, Props extends VNodeProps<Element> = VNodeProps<Element>>(
-    sel: string,
-    data: Props): VNode<T>
+    tagName: ValidTagNames,
+    props: Props): VNode<T>
   <T extends Node, Props extends VNodeProps<Element> = VNodeProps<Element>>(
-    sel: string,
+    tagName: ValidTagNames,
     children: HyperscriptChildren): VNode<T, Props>
 
   <T extends Node, Props extends VNodeProps<Element> = VNodeProps<Element>>(
-    sel: string,
-    data: Props,
+    tagName: ValidTagNames,
+    props: Props,
     children: HyperscriptChildren): VNode<T, Props>
 }

--- a/src/hyperscript/hasCssSelector/hasCssSelector.test.ts
+++ b/src/hyperscript/hasCssSelector/hasCssSelector.test.ts
@@ -9,44 +9,44 @@ describe('hasCssSelector', () => {
   // wildcard
   describe('given * as selector and a VNode', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('*', div('.foo')))
+      assert.ok(hasCssSelector('*', div({ className: 'foo' })))
     })
   })
 
   // tagName, className, and id matching
   describe('given a class selector .foo and VNode with class foo', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo', div('.foo')))
+      assert.ok(hasCssSelector('.foo', div({ className: 'foo' })))
     })
   })
 
   describe('given a class selector .bar and VNode with class foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('.bar', div('.foo')))
+      assert.ok(!hasCssSelector('.bar', div({ className: 'foo' })))
     })
   })
 
   describe('given a class selector xbar and VNode with class bar', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('xbar', div('.bar')))
+      assert.ok(!hasCssSelector('xbar', div({ className: 'bar' })))
     })
   })
 
   describe('given a class selector .foo.bar and VNode with classes foo and bar', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo.bar', div('.foo.bar')))
+      assert.ok(hasCssSelector('.foo.bar', div({ className: 'foo bar' })))
     })
   })
 
   describe('given a class selector .foo.bar and VNode with classes bar and foo', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo.bar', div('.bar.foo')))
+      assert.ok(hasCssSelector('.foo.bar', div({ className: 'bar foo' })))
     })
   })
 
   describe('given a class selector .foo.bar.baz and VNode with classes bar foo and baz', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo.bar.baz', div('.baz.bar.foo')))
+      assert.ok(hasCssSelector('.foo.bar.baz', div({ className: 'baz bar foo' })))
     })
   })
 
@@ -58,63 +58,63 @@ describe('hasCssSelector', () => {
 
   describe('given an id selector #foo and VNode with id foo', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('#foo', div('#foo')))
+      assert.ok(hasCssSelector('#foo', div({ id: 'foo' })))
     })
   })
 
   describe('given an id selector #bar and VNode with id foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('#bar', div('#foo')))
+      assert.ok(!hasCssSelector('#bar', div({ id: 'foo' })))
     })
   })
 
   describe('given an id selector #foo#bar and VNode with id foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('#foo#bar', div('#foo')))
+      assert.ok(!hasCssSelector('#foo#bar', div({ id: 'foo' })))
     })
   })
 
   describe('given a cssSelector .foo#bar and VNode with class foo and id bar', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo#bar', div('.foo#bar')))
+      assert.ok(hasCssSelector('.foo#bar', div({ className: 'foo', id: 'bar' })))
     })
   })
 
   describe('given a cssSelector .foo#bar and VNode with class foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('.foo#bar', div('.foo')))
+      assert.ok(!hasCssSelector('.foo#bar', div({ className: 'foo' })))
     })
   })
 
   describe('given a cssSelector #bar.foo and VNode with class foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('#bar.foo', div('.foo')))
+      assert.ok(!hasCssSelector('#bar.foo', div({ className: 'foo' })))
     })
   })
 
   // describe('given a cssSelector .foo .bar and VNode with classes foo and bar', () => {
   //   it('throws error', () => {
   //     assert.throws(() => {
-  //       hasCssSelector('.foo .bar', div('.foo.bar'));
+  //       hasCssSelector('.foo .bar', div({ className: 'foo bar' }));
   //     }, /CSS selectors can not contain spaces/);
   //   });
   // });
 
   describe('given a cssSelector .foo#bar.baz and VNode with classes foo and baz and id bar', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('.foo#bar.baz', div('.foo#bar.baz')))
+      assert.ok(hasCssSelector('.foo#bar.baz', div({ className: 'foo baz', id: 'bar' })))
     })
   })
 
   describe('given cssSelector .foo#bar.baz and VNode with class foo and id bar', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('.foo#bar.baz', div('.foo#bar')))
+      assert.ok(!hasCssSelector('.foo#bar.baz', div({ id: 'bar', className: 'foo' })))
     })
   })
 
   describe('given cssSelector .foo#bar.baz and VNode with class baz and id bar', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('.foo#bar.baz', div('.baz#bar')))
+      assert.ok(!hasCssSelector('.foo#bar.baz', div({ className: 'baz', id: 'bar' })))
     })
   })
 
@@ -126,13 +126,13 @@ describe('hasCssSelector', () => {
 
   describe('given a cssSelector div.foo and VNode with tagName div and class foo', () => {
     it('returns true', () => {
-      assert.ok(hasCssSelector('div.foo', div('.foo')))
+      assert.ok(hasCssSelector('div.foo', div({ className: 'foo' })))
     })
   })
 
   describe('given a cssSelector h2.foo and VNode with tagName div and class foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('h2.foo', div('.foo')))
+      assert.ok(!hasCssSelector('h2.foo', div({ className: 'foo' })))
     })
   })
 
@@ -144,7 +144,7 @@ describe('hasCssSelector', () => {
 
   describe('given a cssSelector div.foo and VNode with tagName div and id foo', () => {
     it('returns false', () => {
-      assert.ok(!hasCssSelector('div.foo', div('#foo')))
+      assert.ok(!hasCssSelector('div.foo', div({ id: 'foo' })))
     })
   })
 
@@ -153,7 +153,7 @@ describe('hasCssSelector', () => {
     ' tagName div and id foo and class bar', function()
   {
     it('returns true', () => {
-      assert.ok(hasCssSelector('div#foo.bar', div('#foo.bar')))
+      assert.ok(hasCssSelector('div#foo.bar', div({ id: 'foo', className: 'bar' })))
     })
   },
   )
@@ -225,7 +225,7 @@ describe('hasCssSelector', () => {
     describe(`returns false when`, () => {
       it(`is given a vNode with attribute data-foo with value of foobar`, () => {
         assert.ok(
-          !hasCssSelector('[data-foo$=foo]', div('', { attrs: { 'data-foo': 'foobar' } }, [])),
+          !hasCssSelector('[data-foo$=foo]', div({ attrs: { 'data-foo': 'foobar' } }, [])),
         )
       })
     })
@@ -235,15 +235,15 @@ describe('hasCssSelector', () => {
   describe('psuedo-selectors', () => {
     describe(':first-child', () => {
       it('returns true when a vNode is the first child of its parent vNode', () => {
-        const child = div('.hi', {})
-        div('.parent', [ child, div({}, []) ])
+        const child = div({ className: 'hi' })
+        div({ className: 'parent' }, [ child, div({}, []) ])
 
         assert.ok(hasCssSelector(':first-child', child))
       })
 
       it('returns false when a vNode is not its parents first child', () => {
-        const child = div('.hi', {})
-        div('.parent', [ div({}, []), child ])
+        const child = div({ className: 'hi' })
+        div({ className: 'parent' }, [ div({}, []), child ])
 
         assert.ok(!hasCssSelector(':first-child', child))
       })
@@ -251,15 +251,15 @@ describe('hasCssSelector', () => {
 
     describe(':last-child', () => {
       it('returns true when a vNode is the last child of its parent vNode', () => {
-        const child = div('.hi', {})
-        div('.parent', [ div({}, []), child ])
+        const child = div({ className: 'hi' })
+        div({ className: 'parent' }, [ div({}, []), child ])
 
         assert.ok(hasCssSelector(':last-child', child))
       })
 
       it('returns false when a vNode is not its parents last child', () => {
-        const child = div('.hi', {})
-        div('.parent', [ child, div({}, []) ])
+        const child = div({ className: 'hi' })
+        div({ className: 'parent' }, [ child, div({}, []) ])
 
         assert.ok(!hasCssSelector(':last-child', child))
       })
@@ -268,15 +268,15 @@ describe('hasCssSelector', () => {
     describe('nth:child', () => {
       describe('given :nth-child(1)', () => {
         it('returns true when a vNode is the at index `n`', () => {
-          const child = div('.hi', {})
-          div('.parent', [ div({}, []), child ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ div({}, []), child ])
 
           assert.ok(hasCssSelector(':nth-child(1)', child))
         })
 
         it('returns false when a vNode is not is not at index `n`', () => {
-          const child = div('.hi', {})
-          div('.parent', [ child, div({}, []) ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ child, div({}, []) ])
 
           assert.ok(!hasCssSelector(':nth-child(1)', child))
         })
@@ -284,15 +284,15 @@ describe('hasCssSelector', () => {
 
       describe('given :nth-child(odd)', () => {
         it('returns true when a vNode is the at odd index', () => {
-          const child = div('.hi', {})
-          div('.parent', [ div({}, []), child ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ div({}, []), child ])
 
           assert.ok(hasCssSelector(':nth-child(odd)', child))
         })
 
         it('returns false when a vNode is not is not at odd index', () => {
-          const child = div('.hi', {})
-          div('.parent', [ child, div({}, []) ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ child, div({}, []) ])
 
           assert.ok(!hasCssSelector(':nth-child(odd)', child))
         })
@@ -300,15 +300,15 @@ describe('hasCssSelector', () => {
 
       describe('given :nth-child(even)', () => {
         it('returns true when a vNode is the at even index', () => {
-          const child = div('.hi', {})
-          div('.parent', [ child, div({}, []) ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ child, div({}, []) ])
 
           assert.ok(hasCssSelector(':nth-child(even)', child))
         })
 
         it('returns false when a vNode is not is not at odd index', () => {
-          const child = div('.hi', {})
-          div('.parent', [ div({}, []), child ])
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [ div({}, []), child ])
 
           assert.ok(!hasCssSelector(':nth-child(even)', child))
         })
@@ -316,8 +316,8 @@ describe('hasCssSelector', () => {
 
       describe('given :nth-child(3n+0)', () => {
         it('returns true when a vNode is at a children index multiples of 3', () => {
-          const child = div('.hi', {})
-          div('.parent', [
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [
             div({}),
             div({}),
             div({}),
@@ -329,8 +329,8 @@ describe('hasCssSelector', () => {
         })
 
         it('returns false when a vNode is not at a children index multiples of 3', () => {
-          const child = div('.hi', {})
-          div('.parent', [
+          const child = div({ className: 'hi' })
+          div({ className: 'parent' }, [
             div({}),
             child,
             div({}),
@@ -409,14 +409,14 @@ describe('hasCssSelector', () => {
       it('returns true given a vNode with className .foo' +
          ' that is descendant of a div', () =>
       {
-        const child = div('.foo')
+        const child = div({ className: 'foo' })
         div([ child ])
 
         assert.ok(hasCssSelector('div .foo', child))
       })
 
       it('returns false given a vNode of className .bar', () => {
-        const vNode = div('.bar')
+        const vNode = div({ className: 'bar' })
         assert.ok(!hasCssSelector('div .foo', vNode))
       })
     })
@@ -425,8 +425,8 @@ describe('hasCssSelector', () => {
       it('returns true given a vNode with tagName `div` with a child with ' +
         'className .foo containing a child with className .bar', () =>
       {
-        const child = div('.bar')
-        div([ div('.foo', [ child ]) ])
+        const child = div({ className: 'bar' })
+        div([ div({ className: 'foo' }, [ child ]) ])
 
         assert.ok(hasCssSelector('div .foo .bar', child))
       })
@@ -436,8 +436,8 @@ describe('hasCssSelector', () => {
       it('returns false given a vNode with tagName `div` with a child with ' +
         'className .foo containing a child with className .bar', () =>
       {
-        const child = div('.bar')
-        div([ div('.foo', [ child ]) ])
+        const child = div({ className: 'bar' })
+        div([ div({ className: 'foo' }, [ child ]) ])
 
         assert.ok(!hasCssSelector('a .foo .bar', child))
       })
@@ -447,7 +447,7 @@ describe('hasCssSelector', () => {
       it('returns true given a vNode with tagName `div` with a child with ' +
         'className .foo', () =>
       {
-        const child = div('.foo')
+        const child = div({ className: 'foo' })
         div([ child ])
         assert.ok(hasCssSelector('div > .foo', child))
       })
@@ -455,7 +455,7 @@ describe('hasCssSelector', () => {
       it('returns false given a vNode with tagName `div` with a child with ' +
         'className .bar', () =>
       {
-        const child = div('.bar')
+        const child = div({ className: 'bar' })
         div([ child ])
 
         assert.ok(!hasCssSelector('div > .foo', child))
@@ -466,8 +466,8 @@ describe('hasCssSelector', () => {
       it('returns true when given a vNode with className bar preceded ' +
          'by vNode with className foo', () =>
       {
-        const vNode = div('.bar')
-        div([ div('.foo'), vNode ])
+        const vNode = div({ className: 'bar' })
+        div([ div({ className: 'foo' }), vNode ])
 
         assert.ok(hasCssSelector('.foo + .bar', vNode))
       })
@@ -475,7 +475,7 @@ describe('hasCssSelector', () => {
       it('returns false when given a vNode with className bar preceded ' +
          'by vNode with className baz', () =>
       {
-        const vNode = div('.bar')
+        const vNode = div({ className: 'bar' })
         div([ div('.baz'), vNode ])
 
         assert.ok(!hasCssSelector('.foo + .bar', vNode))
@@ -486,8 +486,8 @@ describe('hasCssSelector', () => {
       it('returns true when given a vNode with className bar preceded ' +
          'by vNode with className foo', () =>
       {
-        const vNode = div('.bar')
-        div([ div('.foo'), div(), div(), vNode ])
+        const vNode = div({ className: 'bar' })
+        div([ div({ className: 'foo' }), div(), div(), vNode ])
 
         assert.ok(hasCssSelector('.foo ~ .bar', vNode))
       })
@@ -495,7 +495,7 @@ describe('hasCssSelector', () => {
       it('returns false when given a vNode with className bar preceded ' +
          'by vNode with className baz', () =>
       {
-        const vNode = div('.bar')
+        const vNode = div({ className: 'bar' })
         div([ div('.baz'), vNode ])
 
         assert.ok(!hasCssSelector('.foo ~ .bar', vNode))
@@ -504,38 +504,38 @@ describe('hasCssSelector', () => {
 
     describe('complicated selectors', () => {
       it('should return true given `div > .parent > .foo ~ .bar`', () => {
-        const child = div('.bar')
-        const sibling = div('.foo')
-        const parent = div('.parent', [ sibling, child ])
-        div('.grandparent', [ parent ])
+        const child = div({ className: 'bar' })
+        const sibling = div({ className: 'foo' })
+        const parent = div({ className: 'parent' }, [ sibling, child ])
+        div({ className: 'grandparent' }, [ parent ])
 
         assert.ok(hasCssSelector(`div > .parent > .foo ~ .bar`, child))
       })
 
       it('should return true given `p > .foo, div .bar`', () => {
-        const child = div('.bar')
+        const child = div({ className: 'bar' })
         div([ child ])
 
         const selector = `p > .foo, div .bar`
 
         assert.ok(hasCssSelector(selector, child))
 
-        const child2 = div('.foo')
+        const child2 = div({ className: 'foo' })
         p([ child2 ])
 
         assert.ok(hasCssSelector(selector, child2))
       })
 
       it('should return true given `div .bar, .parent > .foo`', () => {
-        const child = div('.bar')
+        const child = div({ className: 'bar' })
         div([ child ])
 
         const selector = `div .bar, .parent > .foo`
 
         assert.ok(hasCssSelector(selector, child))
 
-        const child2 = div('.foo')
-        p('.parent', [ child2 ])
+        const child2 = div({ className: 'foo' })
+        p({ className: 'parent' }, [ child2 ])
 
         assert.ok(hasCssSelector(selector, child2))
       })

--- a/src/hyperscript/hasCssSelector/matchBasicCssSelector.ts
+++ b/src/hyperscript/hasCssSelector/matchBasicCssSelector.ts
@@ -14,11 +14,9 @@ export function matchBasicCssSelector(cssSelector: string, vNode: VNode) {
 
   const parsedClassNames = className && className.split(' ') || []
 
-  const vNodeClassNames = vNode.className && vNode.className.split(' ') || []
-
   const { props: { className: propsClassName = '', id: propsId } } = vNode
 
-  vNodeClassNames.push(...propsClassName.split(' '))
+  const vNodeClassNames = propsClassName.split(' ')
 
   for (let i = 0; i < parsedClassNames.length; ++i) {
     const parsedClassName = parsedClassNames[i]
@@ -27,5 +25,7 @@ export function matchBasicCssSelector(cssSelector: string, vNode: VNode) {
       return false
   }
 
-  return propsId ? id === propsId : id === vNode.id
+  if (id) return propsId === id
+
+  return true
 }

--- a/src/hyperscript/hyperscript-helpers.ts
+++ b/src/hyperscript/hyperscript-helpers.ts
@@ -74,10 +74,6 @@ export interface HyperscriptHelperFn<
 >
 {
   (): VNode<T, Props>
-  (classNameOrId: string, data: Props, children: HyperscriptChildren): VNode<T, Props>
-  (classNameOrId: string, data: Props): VNode<T, Props & VNodeProps<T>>
-  (classNameOrId: string, children: HyperscriptChildren): VNode<T, Props>
-  (classNameOrId: string): VNode<T, Props>
   (data: Props): VNode<T, Props & VNodeProps<T>>
   (data: Props, children: HyperscriptChildren): VNode<T, Props>
   (children: HyperscriptChildren): VNode<T, Props>
@@ -89,18 +85,16 @@ export function hh<T extends Element, Props extends VNodeProps<Element> = VNodeP
 ): HyperscriptHelperFn<T, Props>
 {
   return function(): VNode<T, Props> {
-    const selector = arguments[0]
-    const data = arguments[1]
-    const children = arguments[2]
+    const data = arguments[0]
+    const children = arguments[1]
 
-    if (isSelector(selector))
-      if (Array.isArray(data)) return h<T, Props>(tagName + selector, {} as Props, data)
-      else if (typeof data === 'object') return h<T, Props>(tagName + selector, data, children)
-      else return h<T, Props>(tagName + selector, data || {}) as VNode<T, Props>
+    if (Array.isArray(data))
+      return h<T, Props>(tagName, {} as Props, data)
 
-    if (Array.isArray(selector)) return h<T, Props>(tagName, {} as Props, selector)
-    else if (typeof selector === 'object') return h<T, Props>(tagName, selector, data)
-    else return h<T, Props>(tagName, selector || {}) as VNode<T, Props>
+    if (typeof data === 'object')
+      return h<T, Props>(tagName, data, children)
+
+    return h<T, Props>(tagName, data || {}) as VNode<T, Props>
   }
 }
 

--- a/src/hyperscript/querySelectorAll.test.ts
+++ b/src/hyperscript/querySelectorAll.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+
 import { h } from './h'
 import { querySelectorAll } from './querySelectorAll'
 
@@ -6,9 +7,9 @@ describe('querySelectorAll', () => {
   describe('given a cssSelector and a vNode with children', () => {
     it('returns all vNodes that match given cssSelector', () => {
       const vNode = h('div', {}, [
-        h('a.hi'),
-        h('b.hi'),
-        h('br.hi'),
+        h('a', { className: 'hi' }),
+        h('b', { className: 'hi' }),
+        h('br', { className: 'hi' }),
       ])
 
       const matches = querySelectorAll('.hi', vNode)
@@ -17,18 +18,18 @@ describe('querySelectorAll', () => {
       const [ a, b, br ] = matches
 
       assert.strictEqual(a.tagName, 'a')
-      assert.strictEqual(a.className, 'hi')
+      assert.strictEqual(a.props.className, 'hi')
       assert.strictEqual(b.tagName, 'b')
-      assert.strictEqual(b.className, 'hi')
+      assert.strictEqual(b.props.className, 'hi')
       assert.strictEqual(br.tagName, 'br')
-      assert.strictEqual(br.className, 'hi')
+      assert.strictEqual(br.props.className, 'hi')
     })
 
     it('returns only vNodes with a given scope', () => {
       const vNode = h('div', { scope: 'hi' }, [
-        h('a.hi'),
-        h('b.hi', { scope: 'hello' }),
-        h('br.hi', { scope: 'bye' }),
+        h('a', { className: 'hi' }),
+        h('b', { className: 'hi', scope: 'hello' }),
+        h('br', { className: 'hi', scope: 'bye' }),
       ])
 
       const matches = querySelectorAll('.hi', vNode)
@@ -38,7 +39,7 @@ describe('querySelectorAll', () => {
       const [ a ] = matches
 
       assert.strictEqual(a.tagName, 'a')
-      assert.strictEqual(a.className, 'hi')
+      assert.strictEqual(a.props.className, 'hi')
     })
   })
 })

--- a/src/hyperscript/svg-helpers.ts
+++ b/src/hyperscript/svg-helpers.ts
@@ -3,10 +3,6 @@ import { SvgTagNames, VNode, VNodeProps } from '../'
 
 export interface SvgHyperscriptHelperFn<T extends SVGElement> {
   (): VNode<T>
-  (classNameOrId: string, data: VNodeProps<T>, children: HyperscriptChildren): VNode<T>
-  (classNameOrId: string, data: VNodeProps<T>): VNode<T>
-  (classNameOrId: string, children: HyperscriptChildren): VNode<T>
-  (classNameOrId: string): VNode<T>
   (data: VNodeProps<T>): VNode<T>
   (data: VNodeProps<T>, children: HyperscriptChildren): VNode<T>
   (children: HyperscriptChildren): VNode<T>
@@ -14,24 +10,16 @@ export interface SvgHyperscriptHelperFn<T extends SVGElement> {
 
 function hh <T extends SVGElement>(tagName: SvgTagNames): SvgHyperscriptHelperFn<T> {
   return function(): VNode<T> {
-    const selector = arguments[0]
-    const data = arguments[1]
-    const children = arguments[2]
+    const data = arguments[0]
+    const children = arguments[1]
 
-    if (isSelector(selector))
-      if (Array.isArray(data))
-        return h<T>(tagName + selector, {}, data)
-      else if (typeof data === 'object')
-        return h<T>(tagName + selector, data, children)
-      else
-        return h<T>(tagName + selector, {})
+    if (Array.isArray(data))
+      return h<T>(tagName, {}, data)
 
-    if (Array.isArray(selector))
-      return h<T>(tagName, {}, selector)
-    else if (typeof selector === 'object')
-      return h<T>(tagName, selector, data)
-    else
-      return h<T>(tagName, {})
+    if (typeof data === 'object')
+      return h<T>(tagName, data, children)
+
+    return h<T>(tagName, {})
   }
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -7,34 +7,32 @@ import {
   VNodeProps,
 } from './'
 
-import { AttributesModule } from './modules/attributes'
-import { EventsModule } from './modules/events'
-import { FocusModule } from './modules/focus'
 import { ModuleCallbacks } from './modules/ModuleCallbacks'
-import { PropsModule } from './modules/props'
-import { StylesModule } from './modules/styles'
+import { createAttributesModule } from './modules/attributes'
+import { createClassModule } from './modules/class'
 import { createElement } from './createElement'
+import { createEventsModule } from './modules/events'
+import { createFocusModule } from './modules/focus'
+import { createPropsModule } from './modules/props'
+import { createStylesModule } from './modules/styles'
 import { patchVNode } from './patchVNode'
 import { removeVNodes } from './removeVNodes'
 import { vNodesAreEqual } from './helpers'
 
-export function init<T extends Element = Element>(modules: Array<Module<Element>>) {
-  const attributesModule = new AttributesModule()
-  const propsModule = new PropsModule()
-  const stylesModule = new StylesModule()
-  const focusModule = new FocusModule()
-  const eventsModule = new EventsModule()
+const defaultModules =
+  [
+    createAttributesModule(),
+    createClassModule(),
+    createEventsModule(),
+    createFocusModule(),
+    createPropsModule(),
+    createStylesModule()
+  ]
 
-  const defaultModules =
-    [
-      attributesModule,
-      propsModule,
-      stylesModule,
-      focusModule,
-      eventsModule,
-    ]
-
-  const moduleCallbacks = new ModuleCallbacks(defaultModules.concat(modules))
+export function init<T extends Element = Element>(
+  modules: Array<Module<Element>> = defaultModules)
+{
+  const moduleCallbacks = new ModuleCallbacks(modules)
 
   return function patch(
     formerVNode: ElementVNode<T, VNodeProps<T>>,

--- a/src/modules/attributes.ts
+++ b/src/modules/attributes.ts
@@ -1,6 +1,11 @@
+import { ElementVNode, Module } from '../'
+
 import { BaseModule } from './BaseModule'
-import { ElementVNode } from '../'
 import { emptyVNode } from './emptyVNode'
+
+export function createAttributesModule(): Module {
+  return new AttributesModule()
+}
 
 const NAMESPACE_URIS = {
   xlink: 'http://www.w3.org/1999/xlink',
@@ -23,7 +28,7 @@ for (let i = 0, count = booleanAttributes.length; i < count; i++)
   booleanAttributeDictionary[booleanAttributes[i]] = true
 
 // attributes module
-export class AttributesModule extends BaseModule<Element> {
+class AttributesModule extends BaseModule<Element> {
   public create(vNode: ElementVNode) {
     updateAttributes(emptyVNode, vNode)
   }

--- a/src/modules/class.ts
+++ b/src/modules/class.ts
@@ -1,0 +1,33 @@
+import { ElementVNode, EventHandler, Module, VNode } from '../'
+
+import { BaseModule } from './BaseModule'
+import { emptyVNode } from './emptyVNode'
+
+export function createClassModule(): Module {
+  return new ClassModule()
+}
+
+class ClassModule extends BaseModule {
+  public create(vNode: ElementVNode) {
+    updateClass(emptyVNode, vNode)
+  }
+
+  public update(formerVNode: ElementVNode, vNode: ElementVNode) {
+    updateClass(formerVNode, vNode)
+  }
+}
+
+function updateClass(formerVNode: ElementVNode, vNode: VNode): void {
+  const { props: { class: formerClass = {} }, element: formerElement } = formerVNode
+  const { props: { class: klass = {} }, element } = vNode
+
+  if (formerClass === klass) return
+
+  for (const name in formerClass)
+    if (!klass[name])
+      formerElement.classList.remove(name)
+
+  for (const name in klass)
+    if (klass[name] !== formerClass[name])
+      (element as Element).classList.toggle(name)
+}

--- a/src/modules/emptyVNode.ts
+++ b/src/modules/emptyVNode.ts
@@ -4,8 +4,6 @@ import { VOID } from '../helpers'
 
 export const emptyVNode: ElementVNode<Element, VNodeProps<Element>> = new MostlyVNode(
   VOID,
-  VOID,
-  VOID,
   {},
   VOID,
   VOID,

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,9 +1,13 @@
-import { ElementVNode, EventHandler } from '../'
+import { ElementVNode, EventHandler, Module } from '../'
 
 import { BaseModule } from './BaseModule'
 import { emptyVNode } from './emptyVNode'
 
-export class EventsModule extends BaseModule {
+export function createEventsModule(): Module {
+  return new EventsModule()
+}
+
+class EventsModule extends BaseModule {
   public create(vNode: ElementVNode) {
     updateEventHandlers(emptyVNode, vNode)
   }

--- a/src/modules/focus.ts
+++ b/src/modules/focus.ts
@@ -1,7 +1,12 @@
-import { BaseModule } from './BaseModule'
-import { ElementVNode } from '../'
+import { ElementVNode, Module } from '../'
 
-export class FocusModule extends BaseModule<Element> {
+import { BaseModule } from './BaseModule'
+
+export function createFocusModule(): Module {
+  return new FocusModule()
+}
+
+class FocusModule extends BaseModule<Element> {
   public insert(vNode: ElementVNode) {
     setFocus(vNode)
   }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,1 +1,7 @@
-export * from './BaseModule'
+export { BaseModule } from './BaseModule'
+export { createAttributesModule } from './attributes'
+export { createClassModule } from './class'
+export { createEventsModule } from './events'
+export { createFocusModule } from './focus'
+export { createPropsModule } from './props'
+export { createStylesModule } from './styles'

--- a/src/modules/props.ts
+++ b/src/modules/props.ts
@@ -1,6 +1,11 @@
+import { ElementVNode, Module } from '../'
+
 import { BaseModule } from './BaseModule'
-import { ElementVNode } from '../'
 import { emptyVNode } from './emptyVNode'
+
+export function createPropsModule(): Module {
+  return new PropsModule()
+}
 
 const PROPERTIES_TO_SKIP: Array<string> =
   [
@@ -22,7 +27,7 @@ const PROPERTIES_TO_SKIP: Array<string> =
     'postpatch',
   ]
 
-export class PropsModule extends BaseModule<Element> {
+class PropsModule extends BaseModule<Element> {
   public create(vNode: ElementVNode) {
     updateProps(emptyVNode as ElementVNode, vNode)
   }

--- a/src/modules/styles.ts
+++ b/src/modules/styles.ts
@@ -1,8 +1,13 @@
+import { ElementVNode, Module } from '../'
+
 import { BaseModule } from './BaseModule'
-import { ElementVNode } from '../'
 import { emptyVNode } from './emptyVNode'
 
-export class StylesModule extends BaseModule<Element> {
+export function createStylesModule(): Module {
+  return new StylesModule()
+}
+
+class StylesModule extends BaseModule<Element> {
   public pre() {
     setRequestAnimationFrame()
   }

--- a/src/patch.test.ts
+++ b/src/patch.test.ts
@@ -4,7 +4,7 @@ import { BaseModule, ElementVNode, VNode, a, b, div, h, i, init, span } from './
 
 import { elementToVNode } from './elementToVNode'
 
-const patch = init([])
+const patch = init()
 
 function prop(name: string) {
   return function(obj: any): any {
@@ -27,9 +27,8 @@ function getChild(vnode: VNode, index: number): VNode {
     (vnode &&
       vnode.children &&
       (vnode.children as Array<any>).length >= index + 1 &&
-      (vnode.children[index] as VNode)) ||
-    h('fuckedup', {}, [])
-  )
+      (vnode.children[index] as VNode))
+  ) as VNode
 }
 
 const inner = prop('innerHTML')

--- a/src/patchVNode/updateElement.test.ts
+++ b/src/patchVNode/updateElement.test.ts
@@ -20,34 +20,6 @@ describe('updateElement', () => {
     assert.strictEqual(elementVNode.element.getAttribute(SCOPE_ATTRIBUTE), 'hello')
   })
 
-  it(`removes a previous className`, () => {
-    const className = 'foo'
-
-    const formerVNode = h('div', { className }, []) as ElementVNode
-    formerVNode.element = document.createElement('div')
-    formerVNode.element.className = className
-
-    const vNode = h('div', {}, [])
-
-    const { element } = updateElement(formerVNode, vNode)
-
-    assert.strictEqual(element.className, '')
-  })
-
-  it(`removes a previous id`, () => {
-    const id = 'foo'
-
-    const formerVNode = h('div', { id }, []) as ElementVNode
-    formerVNode.element = document.createElement('div')
-    formerVNode.element.id = id
-
-    const vNode = h('div', {}, [])
-
-    const { element } = updateElement(formerVNode, vNode)
-
-    assert.strictEqual(element.id, '')
-  })
-
   it(`removes previous scope`, () => {
     const scope = 'hi'
 

--- a/src/patchVNode/updateElement.ts
+++ b/src/patchVNode/updateElement.ts
@@ -4,10 +4,7 @@ export function updateElement(formerVNode: VNode, vNode: VNode): ElementVNode {
   const node = vNode.element = formerVNode.element as Node
 
   if (isElement(node)) {
-    const { id, className, scope } = vNode
-
-    node.id = id || ''
-    node.className = className || ''
+    const { scope } = vNode
 
     if (scope)
       node.setAttribute(SCOPE_ATTRIBUTE, scope)

--- a/src/types/VirtualNode.ts
+++ b/src/types/VirtualNode.ts
@@ -6,8 +6,6 @@ import { VNodeEvents } from './VNodeEventTypes'
 
 export interface VNode<T extends Node = Node, Props = VNodeProps<Element>> {
   tagName: string | void
-  id: string | void
-  className: string | void
   props: Props
   children: Array<VNode> | ReadonlyArray<VNode> | void
   text: string | void
@@ -33,8 +31,6 @@ export interface ElementVNode<T extends Element = Element, Props = VNodeProps<T>
 
 export interface TextVNode extends VNode<Text> {
   tagName: void
-  id: void
-  className: void
   children: void
   text: string
   key: void


### PR DESCRIPTION
Closes #23 

# Breaking Changes

## `h` only accepts tagName as the first property
```typescript
// before
h('h1.foo')
// after
h('h1', { className: 'foo' }) 
```

## hyperscript-helpers only accepts props and children/text
```typescript
// before
div('.foo#bar')
// after
div({ className: 'foo', id: 'bar' })
```

## `init` no longer forces default modules upon you
There is also now access to factory functions to modules
```typescript
import { 
  createAttributesModule,
  createClassModule,
  createEventsModule,
  createFocusModule,
  createPropsModule,
  createStylesModule } from 'mostly-dom'
 
const patch = init([ createPropsModule() ]) // *only* props module will be used

// for previous behaviors
const patch = init() // notice no parameter
// if not parameter is given *all* modules are used per default
```

## VNode no longer has properties `.className` or `.id`

