### PR TITLE
Fix unsatisfied constraint in VNodeEventTypes.ts

### DIFF
--- a/src/types/VNodeEventTypes.ts
+++ b/src/types/VNodeEventTypes.ts
@@ -5,7 +5,7 @@ export type VNodeEvent<T, Ev extends Event> = Ev & { target: T }
 export type EventHandler<T extends Element, Ev extends Event> =
   (event: VNodeEvent<T, Ev>, vNode: ElementVNode<T>) => any
 
-export type VNodeEvents<T extends Element, EventMap extends object> = {
+export type VNodeEvents<T extends Element, EventMap extends { [K in keyof EventMap]: Event }> = {
   readonly [K in keyof EventMap]?: EventHandler<T, EventMap[K]>
 }
 


### PR DESCRIPTION
Fix `Type 'EventMap[K]' does not satisfy the constraint 'Event'.`

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed or the feature I built
- [ ] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`